### PR TITLE
Proper include() behavior for Arrays of Pointers

### DIFF
--- a/src/ObjectStore.js
+++ b/src/ObjectStore.js
@@ -320,13 +320,19 @@ function storeQueryResults(
     var flat = flatten(results[i]);
     var id = storeObject(flat);
     if (includes.length) {
+      var flattenAndStoreValue = (val) => storeObject(flatten(val));
       for (var inclusion = 0; inclusion < includes.length; inclusion++) {
         var inclusionChain = includes[inclusion];
         var cur = results[i];
         for (var col = 0; cur && col < inclusionChain.length; col++) {
           cur = cur.get(inclusionChain[col]);
           if (cur) {
-            storeObject(flatten(cur));
+            // An array from an inclusion needs it's children stored.
+            if (Array.isArray(cur)) {
+              cur.forEach(flattenAndStoreValue);
+            } else {
+              flattenAndStoreValue(cur);
+            }
           }
         }
       }
@@ -383,15 +389,28 @@ function deepFetch(id: Id, seen?: Array<string>): ?FlattenedObjectData {
   var source = store[id].data;
   var obj = {};
   var seenChildren = [];
-  for (var attr in source) {
-    var sourceVal = source[attr];
-    if (sourceVal && typeof sourceVal === 'object' && sourceVal.__type === 'Pointer') {
-      var childId = new Id(sourceVal.className, sourceVal.objectId);
+  var populatePointer = function(val) {
+    if (val && typeof val === 'object' && val.__type === 'Pointer') {
+      var childId = new Id(val.className, val.objectId);
       if (seen.indexOf(childId.toString()) < 0 && store[childId]) {
         seenChildren = seenChildren.concat([childId.toString()]);
-        sourceVal = deepFetch(childId, seen.concat(seenChildren));
+        return deepFetch(childId, seen.concat(seenChildren));
       }
     }
+
+    return val;
+  };
+
+  for (var attr in source) {
+    var sourceVal = source[attr];
+
+    // Arrays of pointers may need to be populated
+    if (Array.isArray(sourceVal)) {
+      sourceVal = sourceVal.map(populatePointer);
+    } else {
+      sourceVal = populatePointer(sourceVal);
+    }
+
     obj[attr] = sourceVal;
   }
   return obj;

--- a/src/__tests__/ObjectStore-test.js
+++ b/src/__tests__/ObjectStore-test.js
@@ -325,8 +325,6 @@ describe('Object storage', function() {
     ObjectStore.storeQueryResults(results, query);
     expectedHash = queryHash(query);
     expectedSubscribers[expectedHash] = true;
-    console.log(ObjectStore._rawStore);
-    console.log(ObjectStore._rawStore['Item:I1'].data.children);
     expect(ObjectStore._rawStore).toEqual({
       'Item:I1': {
         data: {

--- a/src/__tests__/ObjectStore-test.js
+++ b/src/__tests__/ObjectStore-test.js
@@ -316,6 +316,87 @@ describe('Object storage', function() {
         queries: {}
       }
     });
+
+    query.include('children');
+    results[0].set('children', [
+      new Item({ id: 'I4', value: 14 }),
+      new Item({ id: 'I5', value: 15 })
+    ]);
+    ObjectStore.storeQueryResults(results, query);
+    expectedHash = queryHash(query);
+    expectedSubscribers[expectedHash] = true;
+    console.log(ObjectStore._rawStore);
+    console.log(ObjectStore._rawStore['Item:I1'].data.children);
+    expect(ObjectStore._rawStore).toEqual({
+      'Item:I1': {
+        data: {
+          id: new Id('Item', 'I1'),
+          className: 'Item',
+          objectId: 'I1',
+          value: 11,
+          child: {
+            __type: 'Pointer',
+            className: 'Item',
+            objectId: 'I2'
+          },
+          children: [
+            {
+              __type: 'Pointer',
+              className: 'Item',
+              objectId: 'I4'
+            },
+            {
+              __type: 'Pointer',
+              className: 'Item',
+              objectId: 'I5'
+            }
+          ]
+        },
+        queries: expectedSubscribers
+      },
+      'Item:I2': {
+        data: {
+          id: new Id('Item', 'I2'),
+          className: 'Item',
+          objectId: 'I2',
+          value: 12,
+          child: {
+            __type: 'Pointer',
+            className: 'Item',
+            objectId: 'I3'
+          }
+        },
+        queries: {}
+      },
+      'Item:I3': {
+        data: {
+          id: new Id('Item', 'I3'),
+          className: 'Item',
+          objectId: 'I3',
+          value: 13
+        },
+        queries: {}
+      },
+      'Item:I4': {
+        data: {
+          id: new Id('Item', 'I4'),
+          className: 'Item',
+          objectId: 'I4',
+          value: 14
+        },
+        queries: {}
+      },
+      'Item:I5': {
+        data: {
+          id: new Id('Item', 'I5'),
+          className: 'Item',
+          objectId: 'I5',
+          value: 15
+        },
+        queries: {}
+      }
+    });
+
   });
 
   it('fetches objects to fill pointer values', function() {
@@ -374,6 +455,44 @@ describe('Object storage', function() {
         }
       }
     });
+
+    results = new Item({
+      id: 'I1',
+      value: 11,
+      children: [
+        new Item({
+          id: 'I2',
+          value: 12
+        }),
+        new Item({
+          id: 'I3',
+          value: 13
+        })
+      ]
+    });
+    query = new Parse.Query(Item).include('children');
+    ObjectStore.storeQueryResults(results, query);
+    expect(ObjectStore.deepFetch(new Id('Item', 'I1'))).toEqual({
+      id: new Id('Item', 'I1'),
+      className: 'Item',
+      objectId: 'I1',
+      value: 11,
+      children: [
+        {
+          id: new Id('Item', 'I2'),
+          className: 'Item',
+          objectId: 'I2',
+          value: 12
+        },
+        {
+          id: new Id('Item', 'I3'),
+          className: 'Item',
+          objectId: 'I3',
+          value: 13
+        }
+      ]
+    });
+
   });
 
   it('supplies data for all pointers that exist at the same depth', function() {


### PR DESCRIPTION
Fixes #91 so that when you .include() a field that is an array of pointers, the referenced objects get stored, and returned in the parent object. Tests included.
