### PR TITLE
Fixing the Logout/currentUser race condition.

### DIFF
--- a/src/ParsePatches.js
+++ b/src/ParsePatches.js
@@ -80,9 +80,9 @@ var patches = {
     });
   },
   logOut: function() {
-    var promise = oldLogOut();
-    LocalSubscriptions.currentUser.update();
-    return promise;
+    return oldLogOut().then(function() {
+      LocalSubscriptions.currentUser.update();
+    });
   },
 };
 


### PR DESCRIPTION
This code change fixes a race condition in the overriden Parse.User.logOut() method.

The `logOut()` method is supposed to reset the current user to `null` but the code path is not waiting for the `oldLogOut()` promise result to update the `currentUser` state in the local subscriptions module (`LocalSubscriptions.js`) which causes the `LocalSubscription.currentUser.update()` method to call the `setCurrentUser(...)` with the stale user object.

**Example**

``` javascript

Parse.User.logOut()
          .then(() => Parse.User.currentAsync())
          .then((user) => { console.log("Current User", user); });
```

The JS code snippet above is supposed to log "null" as the value of the user parameter, but it's logging the old stale user object all the time.
