### PR TITLE
Fix crash when componentWillUnmount is called

### DIFF
--- a/src/ParseComponent.js
+++ b/src/ParseComponent.js
@@ -148,8 +148,10 @@ export default function(React) {
 
     _unsubscribe() {
       for (var name in this._subscriptions) {
-        this._subscriptions[name].dispose();
-      }
+        if (this._subscriptions[name]) {
+          this._subscriptions[name].dispose();
+        }
+    }
       this._subscriptions = {};
     }
 


### PR DESCRIPTION
Sometimes the subscription can be undefined, so now it checks for undefined or not and then disposes the subscription